### PR TITLE
Fixing the ExclusionPathNodeIterator to not just look at the first pa…

### DIFF
--- a/src/main/groovy/com/twcable/grabbit/client/batch/steps/http/CreateHttpConnectionTasklet.groovy
+++ b/src/main/groovy/com/twcable/grabbit/client/batch/steps/http/CreateHttpConnectionTasklet.groovy
@@ -84,6 +84,11 @@ class CreateHttpConnectionTasklet implements Tasklet {
                 .url(getPostURLForRequest(jobParameters))
                 .addHeader('Authorization', Credentials.basic(username, password))
                 .build()
+//        final Request request = new RequestBuilder()
+//                .url(getURLForRequest(jobParameters))
+//                .addHeader('Authorization', Credentials.basic(username, password))
+//                .build()
+
 
         final OkHttpClient client = getNewHttpClient()
 

--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesReader.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesReader.groovy
@@ -42,8 +42,10 @@ class JcrNodesReader implements ItemReader<JcrNode> {
         try {
             if (nodeIterator.hasNext()) {
                 JcrNode jcrNode = nodeIterator.next()
-                log.debug "jcrNode.path=${jcrNode.getPath()}"
-                return jcrNode
+                if (jcrNode != null) {
+                    log.debug "jcrNode.path={}", jcrNode.getPath()
+                    return jcrNode
+                }
             } else {
                 null
             }

--- a/src/main/groovy/com/twcable/grabbit/server/services/ExcludePathNodeIterator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/services/ExcludePathNodeIterator.groovy
@@ -17,6 +17,8 @@
 package com.twcable.grabbit.server.services
 
 import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+
 import javax.jcr.Node as JcrNode
 
 /**
@@ -24,6 +26,7 @@ import javax.jcr.Node as JcrNode
  * Accounts for cases where certain paths(i.e nodes) needs to be excluded.
  */
 @CompileStatic
+@Slf4j
 final class ExcludePathNodeIterator implements Iterator<JcrNode> {
 
     private Iterator<JcrNode> nodeIterator
@@ -53,6 +56,9 @@ final class ExcludePathNodeIterator implements Iterator<JcrNode> {
     }
 
     private boolean isPathInExcludedList(String path) {
-        return excludePathList.any { path.startsWith(it) }
+        boolean result = excludePathList.any { path.startsWith(it + "/") || path.equals(it) }
+
+        log.debug "isPathInExcludedList() : path={}, result={}", path, result
+        return result
     }
 }


### PR DESCRIPTION
…rt of the path to see what it starts with.

We see if it matches or if it starts with that path (plus a forward slash to denote that it's a parent path)